### PR TITLE
날짜 별 적립 내역 API 개발

### DIFF
--- a/src/main/java/com/management/web/controller/MyChallengeController.java
+++ b/src/main/java/com/management/web/controller/MyChallengeController.java
@@ -21,7 +21,7 @@ public class MyChallengeController {
         return participateChallengeService.getMyParticipateChallenge(kakaoId);
     }
     @GetMapping("{challengeId}/users/{kakaoId}")
-    public List<MyChallengeCertDto> getMyChallengeInfo(@PathVariable Integer challengeId, @PathVariable String kakaoId){
+    public List<MyChallengeCertDto> getMyChallengeCertInfo(@PathVariable Integer challengeId, @PathVariable String kakaoId){
         return participateChallengeService.getChallengeCertList(challengeId, kakaoId);
     }
 }

--- a/src/main/java/com/management/web/controller/MyChallengeController.java
+++ b/src/main/java/com/management/web/controller/MyChallengeController.java
@@ -1,5 +1,6 @@
 package com.management.web.controller;
 
+import com.management.web.service.dto.MyChallengeCertDto;
 import com.management.web.service.dto.MyChallengeInfoDto;
 import com.management.web.service.ParticipateChallengeService;
 import org.springframework.web.bind.annotation.*;
@@ -7,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/challenge")
+@RequestMapping("/challenges")
 public class MyChallengeController {
     private final ParticipateChallengeService participateChallengeService;
 
@@ -15,9 +16,12 @@ public class MyChallengeController {
         this.participateChallengeService = participateChallengeService;
     }
 
-    @GetMapping("/{kakaoId}")
+    @GetMapping("/users/{kakaoId}")
     public List<MyChallengeInfoDto> getMyChallengeInfo(@PathVariable String kakaoId){
         return participateChallengeService.getMyParticipateChallenge(kakaoId);
     }
-
+    @GetMapping("{challengeId}/users/{kakaoId}")
+    public List<MyChallengeCertDto> getMyChallengeInfo(@PathVariable Integer challengeId, @PathVariable String kakaoId){
+        return participateChallengeService.getChallengeCertList(challengeId, kakaoId);
+    }
 }

--- a/src/main/java/com/management/web/controller/MyChallengeController.java
+++ b/src/main/java/com/management/web/controller/MyChallengeController.java
@@ -2,10 +2,7 @@ package com.management.web.controller;
 
 import com.management.web.service.dto.MyChallengeInfoDto;
 import com.management.web.service.ParticipateChallengeService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -18,8 +15,9 @@ public class MyChallengeController {
         this.participateChallengeService = participateChallengeService;
     }
 
-    @GetMapping
-    public List<MyChallengeInfoDto> getMyChallengeInfo(@RequestParam String kakaoId){
+    @GetMapping("/{kakaoId}")
+    public List<MyChallengeInfoDto> getMyChallengeInfo(@PathVariable String kakaoId){
         return participateChallengeService.getMyParticipateChallenge(kakaoId);
     }
+
 }

--- a/src/main/java/com/management/web/repository/MemberWebRepository.java
+++ b/src/main/java/com/management/web/repository/MemberWebRepository.java
@@ -1,9 +1,6 @@
 package com.management.web.repository;
 
-import com.management.web.service.dto.MyChallengeInfoDto;
-import com.management.web.service.dto.MyMainInfoDto;
-import com.management.web.service.dto.MyPrivateRankingInfoDto;
-import com.management.web.service.dto.MyRankingInfoDto;
+import com.management.web.service.dto.*;
 
 import java.util.List;
 
@@ -15,6 +12,7 @@ public interface MemberWebRepository {
     List<MyRankingInfoDto> findRankingInfoList();
 
     List<MyChallengeInfoDto> findParticipateChallengeList(String kakaoId);
+    List<MyChallengeCertDto> findChallengeCertList(Integer challengeId, String kakaoId);
 
     MyMainInfoDto findMainInfoByKakaoId(String kakaoId);
 }

--- a/src/main/java/com/management/web/service/ParticipateChallengeService.java
+++ b/src/main/java/com/management/web/service/ParticipateChallengeService.java
@@ -1,5 +1,6 @@
 package com.management.web.service;
 
+import com.management.web.service.dto.MyChallengeCertDto;
 import com.management.web.service.dto.MyChallengeInfoDto;
 import com.management.web.repository.MemberWebRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,5 +15,9 @@ public class ParticipateChallengeService {
 
     public List<MyChallengeInfoDto> getMyParticipateChallenge(String kakaoId){
         return memberWebRepository.findParticipateChallengeList(kakaoId);
+    }
+
+    public List<MyChallengeCertDto> getChallengeCertList(Integer challengeId, String kakaoId){
+        return memberWebRepository.findChallengeCertList(challengeId,kakaoId);
     }
 }

--- a/src/main/java/com/management/web/service/dto/MyChallengeCertDto.java
+++ b/src/main/java/com/management/web/service/dto/MyChallengeCertDto.java
@@ -1,0 +1,18 @@
+package com.management.web.service.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@Builder
+public class MyChallengeCertDto {
+    private Timestamp date;
+    private Integer count;
+
+    public MyChallengeCertDto(Timestamp date, Integer count) {
+        this.date = date;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/management/web/service/dto/MyChallengeInfoDto.java
+++ b/src/main/java/com/management/web/service/dto/MyChallengeInfoDto.java
@@ -13,12 +13,14 @@ public class MyChallengeInfoDto {
     private Integer reward;
     private String username;
     private Integer cnt;
+    private Integer challengeId;
 
-    public MyChallengeInfoDto(String title, Integer savedMoney, Integer reward, String username, Integer cnt) {
+    public MyChallengeInfoDto(String title, Integer savedMoney, Integer reward, String username, Integer cnt,Integer challengeId) {
         this.title = title;
         this.savedMoney = savedMoney;
         this.reward = reward;
         this.username = username;
         this.cnt = cnt;
+        this.challengeId = challengeId;
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fork repository/develop -> upstream/develop

### 변경 사항
- 참여중인 챌린지 목록을 가져오는 getMyChallengeInfo 관련 수정
  - url 수정
  - 쿼리 수정
  - challengeId 필드 추가
- 날짜별 적립내역 기능 추가

### 테스트 결과
- 참여중인 챌린지 목록
<img width="810" alt="image" src="https://github.com/TEAM-HUNDRED/savable-chatbot-server/assets/41178045/61219b9d-8f7c-4e07-9cb6-b3f2a6f3bac3">

- 한 챌린지의 절약 내역 목록
<img width="875" alt="image" src="https://github.com/TEAM-HUNDRED/savable-chatbot-server/assets/41178045/0f2b0cbd-158e-47b3-abc5-d9289f5aa9b1">

